### PR TITLE
feat(app): add project route

### DIFF
--- a/pages/project/index.tsx
+++ b/pages/project/index.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from 'react'
+import styled from 'styled-components'
+import { useTranslation } from 'next-i18next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+
+import domtoimage from 'dom-to-image'
+import { saveAs } from 'file-saver'
+
+import { isClient } from 'utils/env'
+import { Media, MediaContextProvider } from 'utils/media'
+
+import { BACKGROUND_COLOURS, SKIN_COLOURS } from 'constants/body'
+
+import { ProjectLayout, Selector, Skin, Background } from '@/components'
+import { baseTheme, Grid, Box, HeadingH3, Button } from 'danni-s-design-system'
+
+import type { Locale, Page, SinglePage as SinglePageProps } from 'types'
+
+const snapImage = () => {
+  const AvatarNode = document.querySelector('#avatar') as HTMLElement
+  if (isClient() && AvatarNode) {
+    domtoimage
+      .toBlob(AvatarNode, { height: 300, width: 300 })
+      .then(function (blob) {
+        saveAs(blob, 'avatar.png')
+      })
+      .catch(function (error) {
+        console.error('oops, something went wrong!', error)
+      })
+  }
+}
+
+const StyledSaveButton = styled(Button).attrs({
+  my: 'xl',
+  px: 'xl',
+  py: 'm',
+  border: '1px solid accentDark',
+  borderRadius: 's',
+  borderOnHover: 'accentLightest',
+  bg: 'accentDark',
+  color: 'accentLightest',
+  activeColour: 'complementaryDark',
+  transition: 'slow',
+  fontFamily: 'serif',
+  onClick: snapImage,
+})`
+  font-weight: bold;
+  font-size: ${baseTheme.space.xl}px;
+`
+
+const HomePage: Page<SinglePageProps> = () => {
+  const { t } = useTranslation(['avatar'])
+  const [avatar, setAvatarItem] = useState({
+    background: BACKGROUND_COLOURS.MIST,
+    skin: SKIN_COLOURS.CHOCOLATE,
+  })
+
+  return (
+    <MediaContextProvider>
+      <Media greaterThanOrEqual="tablet">
+        <Grid
+          p="m"
+          sx={{ gridTemplateColumns: 'repeat(2, 1fr)', gap: baseTheme.space.l }}
+        >
+          <Box my="m" mx="auto" width="300px" height="300px">
+            <Background id="avatar" colour={avatar.background}>
+              <Skin colour={avatar.skin} />
+            </Background>
+          </Box>
+          <Box>
+            <HeadingH3 as="h1" kind="serif">
+              {t('builder_heading')}
+            </HeadingH3>
+            <Selector {...{ avatar, setAvatarItem }} />
+            <StyledSaveButton>{t('save')}</StyledSaveButton>
+          </Box>
+        </Grid>
+      </Media>
+      <Media lessThan="tablet">
+        <Grid p="m" sx={{ gridTemplateColumns: '1fr', gap: baseTheme.space.m }}>
+          <Box my="m" mx="auto" width="300px" height="300px">
+            <Background id="avatar" colour={avatar.background}>
+              <Skin colour={avatar.skin} />
+            </Background>
+          </Box>
+          <Box>
+            <HeadingH3 as="h1" kind="serif">
+              {t('builder_heading')}
+            </HeadingH3>
+            <Selector {...{ avatar, setAvatarItem }} />
+            <StyledSaveButton mx="auto">{t('save')}</StyledSaveButton>
+          </Box>
+        </Grid>
+      </Media>
+      <Media lessThan="mobile">
+        <Grid sx={{ gridTemplateColumns: '1fr', gap: baseTheme.space.xs }}>
+          <Box my="m" mx="auto" width="300px" height="300px">
+            <Background id="avatar" colour={avatar.background}>
+              <Skin colour={avatar.skin} />
+            </Background>
+          </Box>
+          <Box>
+            <HeadingH3 as="h1" kind="serif">
+              {t('builder_heading')}
+            </HeadingH3>
+            <Selector {...{ avatar, setAvatarItem }} />
+            <StyledSaveButton mx="auto">{t('save')}</StyledSaveButton>
+          </Box>
+        </Grid>
+      </Media>
+    </MediaContextProvider>
+  )
+}
+
+HomePage.Layout = ({ children, ...props }) => (
+  <ProjectLayout {...props}>{children}</ProjectLayout>
+)
+
+export async function getStaticProps({
+  locale,
+}: {
+  locale: Locale
+}): Promise<{ props: SinglePageProps }> {
+  return {
+    props: {
+      locale,
+      ...(await serverSideTranslations(locale, [
+        'common',
+        'languages',
+        'avatar',
+      ])),
+    },
+  }
+}
+
+export default HomePage

--- a/src/components/layouts/ProjectLayout.tsx
+++ b/src/components/layouts/ProjectLayout.tsx
@@ -1,17 +1,14 @@
 import React, { useState, useEffect } from 'react'
-import Router, { useRouter } from 'next/dist/client/router'
+import Router from 'next/dist/client/router'
 
 import { Box, baseTheme, Loader } from 'danni-s-design-system'
-import { Footer, Header } from '.'
 
-import { Layout, Locale } from 'types'
+import { Layout } from 'types'
 
-export const MainLayout: React.FC<Layout> = ({ children }) => {
+export const ProjectLayout: React.FC<Layout> = ({ children }) => {
   const [loading, setLoading] = useState(false)
   const startLoading = () => setLoading(true)
   const stopLoading = () => setLoading(false)
-
-  const { locale, locales } = useRouter()
 
   useEffect(() => {
     Router.events.on('routeChangeStart', startLoading)
@@ -24,10 +21,7 @@ export const MainLayout: React.FC<Layout> = ({ children }) => {
 
   return (
     <>
-      <Header
-        {...{ currentLocale: locale as Locale, locales: locales as Locale[] }}
-      />
-
+      <Box as="header" mb="xl" />
       <Box minHeight={`calc(100vh - ${baseTheme.space.elephant}px)`} p="s">
         {loading ? (
           <Loader
@@ -40,7 +34,7 @@ export const MainLayout: React.FC<Layout> = ({ children }) => {
           children
         )}
       </Box>
-      <Footer />
+      <Box as="footer" mt="xl" />
     </>
   )
 }

--- a/src/components/layouts/index.tsx
+++ b/src/components/layouts/index.tsx
@@ -1,3 +1,4 @@
 export { MainLayout } from './MainLayout'
+export { ProjectLayout } from './ProjectLayout'
 export { Footer } from './Footer'
 export { Header } from './Header'


### PR DESCRIPTION
### What
We can access the project via iframe without the header and footer but with extra margins.

### Why
- If we access the index, then the `isApp` toggle reacts only on client-side, thus, there's a second long (or less) glitch that shows the header still.
- We could try using `getServerSideProps`, it, however, fails to deploy to Vercel, see #5 && #4

### How
- Add a separate route with a different Layout selected.