### PR TITLE
feat(Selector): enhance capability

### DIFF
--- a/constants/body.ts
+++ b/constants/body.ts
@@ -4,6 +4,9 @@ export const BACKGROUND = 'background'
 export const SKIN = 'skin'
 export const CLOTHES = 'clothes'
 
+export const SLIM = 'slim'
+export const PLUMP = 'plump'
+
 export const SELECTOR_NAMES = [BACKGROUND, SKIN, CLOTHES]
 export type SelectorName = keyof typeof SELECTOR_NAMES
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "danni-s-folio",
-  "version": "1.1.0",
+  "name": "danni-s-avatar-builder",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3636,9 +3636,9 @@
       "dev": true
     },
     "danni-s-design-system": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/danni-s-design-system/-/danni-s-design-system-0.2.17.tgz",
-      "integrity": "sha512-9Un+DSe5N80FmCXpfE0afh6jWGsK7SedIfiLhDK4jpZ4vLoALAB2Ydj93ho6ZxX9Fouq9JOBfFgPLRZc0OepAg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/danni-s-design-system/-/danni-s-design-system-0.3.2.tgz",
+      "integrity": "sha512-e/dbVwmZpEvcNMPrLYrSEBQyRCaET0pAff5S0cJgVXV+AXBgg0Bqeq4hdoHhgDQYTkqHUHziKueQbvhKe4jvQA==",
       "requires": {
         "uglifyjs-webpack-plugin": "^2.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@artsy/fresnel": "^1.9.0",
     "@styled-system/css": "^5.1.5",
-    "danni-s-design-system": "0.2.17",
+    "danni-s-design-system": "0.3.2",
     "dom-to-image": "^2.6.0",
     "file-saver": "^2.0.5",
     "framer-motion": "^4.1.17",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -50,7 +50,7 @@ const HomePage: Page<SinglePageProps> = () => {
   const { t } = useTranslation(['avatar'])
   const [avatar, setAvatarItem] = useState({
     background: 'MIST',
-    skin: 'CHOCOLATE',
+    skin: 'slim:CHOCOLATE',
     clothes: 'BLUE',
   })
 

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -12,5 +12,5 @@
   "avatar_builder_meta": "Dannis Avatar-Ersteller",
   "create_avatar": "Erstelle deinen eigenen Avatar!",
   "navigation": "Navigation",
-  "languages": "Verfügbare Sprachen"
+  "languages": "verfügbare Sprachen"
 }

--- a/src/components/BodyParts/Avatar.tsx
+++ b/src/components/BodyParts/Avatar.tsx
@@ -13,13 +13,17 @@ import {
 
 export const Avatar: React.FC<AvatarProps> = avatar => {
   const { skin, clothes, background } = avatar
+
+  const [type, hue] = skin.split(':')
+  const colour = SKIN_COLOURS[hue as SkinColourKey]
+
   return (
     <Box my="m" mx="auto" width="300px" height="300px">
       <Background
         id="avatar"
         colour={BACKGROUND_COLOURS[background as BackgroundColourKey]}
       >
-        <Skin colour={SKIN_COLOURS[skin as SkinColourKey]} />
+        <Skin {...{ type, colour }} />
         <Clothes colour={clothes} />
       </Background>
     </Box>

--- a/src/components/BodyParts/Skin.tsx
+++ b/src/components/BodyParts/Skin.tsx
@@ -4,20 +4,28 @@ import styled from 'styled-components'
 import { darken } from 'polished'
 import { baseTheme, Box, Circle } from 'danni-s-design-system'
 
-import { SKIN_COLOURS, SKIN } from 'constants/body'
+import { SKIN_COLOURS, SKIN, PLUMP, SLIM } from 'constants/body'
 
 import type { Skin as SkinProps, SkinColourKey, SelectorItem } from 'types'
 
-export const Skin: React.FC<SkinProps> = ({ colour }) => (
-  <Box>
-    <Head colour={colour}>
-      <Face colour={colour} />
-    </Head>
-    <Neck colour={colour} />
-  </Box>
-)
+export const Skin: React.FC<SkinProps> = ({ type, colour }) =>
+  type === SLIM ? (
+    <Box>
+      <SlimHead colour={colour}>
+        <Face colour={colour} />
+      </SlimHead>
+      <SlimNeck colour={colour} />
+    </Box>
+  ) : (
+    <Box>
+      <PlumpHead colour={colour}>
+        <Face colour={colour} />
+      </PlumpHead>
+      <PlumpNeck colour={colour} />
+    </Box>
+  )
 
-const Head = styled(Box).attrs({
+const SlimHead = styled(Box).attrs({
   width: baseTheme.space.elephant,
 })<SkinProps>`
   position: absolute;
@@ -29,7 +37,19 @@ const Head = styled(Box).attrs({
   top: 70px;
 `
 
-const Neck = styled(Box)<SkinProps>`
+const PlumpHead = styled(Box).attrs({
+  width: '100px',
+})<SkinProps>`
+  position: absolute;
+  z-index: ${baseTheme.zIndices.upAbove};
+  height: 120px;
+  background: ${({ colour }) => colour};
+  border-radius: 50px;
+  left: calc(50% - 52px);
+  top: 70px;
+`
+
+const SlimNeck = styled(Box)<SkinProps>`
   position: absolute;
   width: 40px;
   height: 50px;
@@ -38,6 +58,16 @@ const Neck = styled(Box)<SkinProps>`
   top: 60%;
   box-shadow: ${({ colour }) =>
     `inset 0px 16px 0px 0px ${darken(0.1, colour)}`};
+`
+const PlumpNeck = styled(Box)<SkinProps>`
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background: ${({ colour }) => colour};
+  left: calc(50% - 25px);
+  top: 60%;
+  box-shadow: ${({ colour }) =>
+    `inset 0px 18px 0px 0px ${darken(0.1, colour)}`};
 `
 
 const Face = styled(Box)<SkinProps>`
@@ -49,25 +79,42 @@ const Face = styled(Box)<SkinProps>`
   z-index: ${baseTheme.zIndices.upAbove};
 `
 
+const Sample: React.FC<Record<string, SkinColourKey>> = ({ skinColour }) => (
+  <Circle
+    size={`${baseTheme.space.xxxl}px`}
+    my="m"
+    mr="m"
+    inlineBlock
+    sx={{
+      background: SKIN_COLOURS[skinColour],
+      border: '1px solid grey',
+    }}
+  />
+)
+
 export const SKINS = (): SelectorItem[] => {
   const skinNodesArray = []
 
+  // First batch. Type: SLIM
   for (const skinColour in SKIN_COLOURS) {
     skinNodesArray.push({
       name: SKIN,
-      id: skinColour,
-      children: (
-        <Circle
-          size={`${baseTheme.space.xxxl}px`}
-          my="m"
-          mr="m"
-          inlineBlock
-          sx={{
-            background: SKIN_COLOURS[skinColour as SkinColourKey],
-            border: '1px solid grey',
-          }}
-        />
-      ),
+      id: `${SLIM}:${skinColour}`,
+      children: <Sample skinColour={skinColour as SkinColourKey} />,
+    })
+  }
+
+  skinNodesArray.push({
+    name: SKIN,
+    id: 'br',
+  })
+
+  // Second batch. Type: PLUMP
+  for (const skinColour in SKIN_COLOURS) {
+    skinNodesArray.push({
+      name: SKIN,
+      id: `${PLUMP}:${skinColour}`,
+      children: <Sample skinColour={skinColour as SkinColourKey} />,
     })
   }
   return skinNodesArray

--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -32,8 +32,8 @@ const NavigationButton = styled(Box).attrs({
   inlineBlock: true,
 })`
   &:hover {
-    background: ${mainTheme.colours.accentLight};
-    transition: background ${mainTheme.transitions.default};
+    box-shadow: 0 0 2px 1px ${mainTheme.colours.complementaryDark};
+    transition: all ${mainTheme.transitions.default};
   }
 `
 const NavigationWrapper: React.FC = ({ children }) => (

--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -91,7 +91,7 @@ export const Selector: React.FC<SelectorProps> = ({
         onSelect={event => makeSelection(event)}
         selectorItems={navigation}
         role={t('navigation')}
-        ariaLabel={t('background')}
+        ariaLabel={t('select')}
       />
       {Selection({
         name: shownSelector as SelectorName,

--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -11,7 +11,7 @@ import {
   CLOTHES,
 } from 'constants/body'
 
-import { List, HoverableText, Button, mainTheme } from 'danni-s-design-system'
+import { List, mainTheme, Box } from 'danni-s-design-system'
 import { BACKGROUNDS, CLOTHES_ITEMS, SKINS } from '.'
 
 import type {
@@ -22,17 +22,22 @@ import type {
   Event,
 } from 'types'
 
+const NavigationButton = styled(Box).attrs({
+  mr: 'xl',
+  my: 'xl',
+  p: 's',
+  color: 'accentDark',
+  bg: 'accentLightest',
+  fontWeight: 'bold',
+  inlineBlock: true,
+})`
+  &:hover {
+    background: ${mainTheme.colours.accentLight};
+    transition: background ${mainTheme.transitions.default};
+  }
+`
 const NavigationWrapper: React.FC = ({ children }) => (
-  <Button activeColour="accentLight" mr="xl" mb="xl" p="s">
-    <HoverableText
-      activeColour="black"
-      color="accentDark"
-      sx={{ fontWeight: 'bold' }}
-      inlineBlock
-    >
-      {children}
-    </HoverableText>
-  </Button>
+  <NavigationButton>{children}</NavigationButton>
 )
 
 const NavigationOptions = () => {
@@ -72,8 +77,6 @@ export const Selector: React.FC<SelectorProps> = ({
 
     if (!value) {
       value = target.parentNode.value
-        ? target.parentNode.value
-        : target.parentNode.parentNode.parentNode.children[0]?.value
     }
 
     const hasChanged = shownSelector !== value
@@ -194,6 +197,7 @@ const StyledInput = styled('input')`
   }
   &:checked + label {
     filter: brightness(0.8);
+    color: red;
   }
   &:checked + label > div {
     box-shadow: 0 0 2px 1px ${mainTheme.colours.complementaryDark};

--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -170,9 +170,13 @@ const SelectorRow: React.FC<SelectorRowProps> = ({
     role={role}
     aria-label={ariaLabel}
   >
-    {selectorItems.map(item => (
-      <SelectorItem key={item.id} {...item} />
-    ))}
+    {selectorItems.map(item =>
+      item.id === 'br' ? (
+        <br key={item.id} />
+      ) : (
+        <SelectorItem key={item.id} {...item} />
+      ),
+    )}
   </List>
 )
 

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -85,6 +85,7 @@ const AvailableLocalesList = ({
     <MediaContextProvider>
       <Media greaterThanOrEqual="tablet">
         <List
+          id={t('common:languages')}
           direction="row"
           role={t('navigation')}
           aria-label={t('languages')}
@@ -199,8 +200,14 @@ export const Header: React.FC<HeaderProps> = ({ currentLocale, locales }) => {
                   mx="m"
                   height={`${baseTheme.space.elephant - baseTheme.space.s}px`}
                 />
-                <Popup height="100vh" p="xl">
+                <Popup
+                  ariaLabelledby={t('common:languages_available')}
+                  ariaDescribedby={t('common:languages')}
+                  height="100vh"
+                  p="xl"
+                >
                   <Flex
+                    id={t('common:languages_available')}
                     justifyContent="center"
                     alignItems="center"
                     height="100%"

--- a/types/BodyParts.d.ts
+++ b/types/BodyParts.d.ts
@@ -3,6 +3,8 @@ import {
   BACKGROUND_COLOURS,
   SKIN_COLOURS,
   CLOTHES_COLOURS,
+  PLUMP,
+  SLIM,
 } from 'constants/body'
 
 import { CLOTHES_PAIR } from '@/components'
@@ -17,7 +19,10 @@ export type GlassesLensProps = {
 
 export type Skin = {
   colour: SkinColour
+  type?: BodyType
 }
+
+export type BodyType = SLIM | PLUMP
 
 export type BackgroundColourKey = keyof typeof BACKGROUND_COLOURS
 type BackgroundColour = BACKGROUND_COLOURS[keyof BACKGROUND_COLOURS]


### PR DESCRIPTION
### What
- Users can select a different type of the same colour pattern;
- e.g. in _skin_ users can select from two body types: slim && plump.

### Why
UX.

### How
- Extend `Selector` options validation;
- Set up detection in `Avatar`;
- Alter main skin builder;
- Add new skin types.